### PR TITLE
Add license headers to source files

### DIFF
--- a/python/applications/alphashapes.py
+++ b/python/applications/alphashapes.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import fig, delaunay, math, numpy, vigra, geomap, crackConvert
 from geomap import Polygon, Vector2
 from flag_constants import BORDER_PROTECTION, ALL_PROTECTION, ALPHA_MARK
@@ -5,7 +33,7 @@ from maputils import nodeAtBorder
 
 __all__ = ["extractMapPoints", "midCrackPoints", "samplingPoints",
            "maxSegmentLength",
-           
+
            "markAlphaShapes", "removeUnmarkedEdges", "alphaBetaMap",
            "findCandidatesForPointCorrection",
 
@@ -85,7 +113,7 @@ def markAlphaShapes(delaunayMap, alpha, beta = 0.0):
             if (squaredNorm(edge.dart().nextSigma()[1]-midPoint) >= radius2 and
                 squaredNorm(edge.dart().nextAlpha().nextSigma()[1]-midPoint) >= radius2):
                 edge.setFlag(ALPHA_MARK)
-    
+
     print "  %d/%d edges and %d/%d faces marked." % (
         sum([edge.flag(ALPHA_MARK) and 1 or 0 for edge in delaunayMap.edgeIter()]), delaunayMap.edgeCount,
         sum([face.flag(ALPHA_MARK) and 1 or 0 for face in delaunayMap.faceIter()]), delaunayMap.faceCount)
@@ -285,7 +313,7 @@ def outputMarkedShapes(delaunayMap, fe, skipInnerEdges = True,
             # continue in the other direction:
             poly.reverse()
             dart = edge.dart().nextAlpha()
-            
+
             drawing = True
             while drawing:
                 drawing = False
@@ -378,7 +406,7 @@ def alphaShapeThinning(dm):
         dart.nextPhi()
         if isSimple(dart.edge()):
             heappush(border, (-dart.edge().length(), dart.edge()))
-    
+
     return changedCount
 
 # --------------------------------------------------------------------

--- a/python/applications/delaunay.py
+++ b/python/applications/delaunay.py
@@ -1,4 +1,32 @@
 # -*- coding: iso-8859-1 -*-
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 
 """(Constrained) Delaunay Triangulation and Chordal Axis Transform
 
@@ -74,7 +102,7 @@ def _pointInHole(polygon, level = 2):
     result = geomap.centroid(polygon)
     if polygon.contains(result):
         return result
-    
+
     result = []
     bbox = polygon.boundingBox()
     midPoint = (bbox.begin() + bbox.end())/2
@@ -167,7 +195,7 @@ def delaunayMap(points, imageSize = (0, 0)):
     if len(points) < 3:
         raise ValueError, \
               "cannot compute Delaunay Triangulation of less than three points"
-    
+
     if triangle:
         nodePositions, edges = triangle.delaunay(points)
         sigma = None
@@ -181,7 +209,7 @@ def delaunayToVoronoi(delaunayMap, clipAtBorder = True):
     Internally, this uses `maputils.dualMap` with an appropriate
     definition of node positions (triangle circumcenters).
     Additionally, a special border handling is needed."""
-    
+
     def createInfiniteNode(dm, edge, voronoiMap, sn, en):
         if sn is not None:
             existingNode = sn
@@ -296,10 +324,10 @@ def fakedConstrainedDelaunayMap(polygons, imageSize, extraPoints = [],
         points.extend(list(polygon))
         del points[-1]
         jumpPoints.append(len(points))
-    
+
     print "- performing Delaunay Triangulation (%d points)..." % len(points)
     nodePositions, edges, sigma = geomap.delaunay(points)
-    
+
     print "- storing result in a GeoMap..."
     result = _delaunayMapFromData(nodePositions, edges, imageSize, sigma)
 
@@ -348,7 +376,7 @@ def fakedConstrainedDelaunayMap(polygons, imageSize, extraPoints = [],
                     #sys.stdout.write(".")
                     #sys.stdout.flush()
         sys.stdout.write("\n")
-    
+
     return result
 
 def faceCDTMap(face, imageSize,
@@ -360,7 +388,7 @@ def faceCDTMap(face, imageSize,
     `face` should be a GeoMap.Face object, and all its contours will
     be extracted.  `mapSize` is used to initialize the GeoMap with the
     resulting edges.
-      
+
     Optional keyword parameters:
 
     simplifyEpsilon
@@ -445,7 +473,7 @@ def chordStrengthProfile(delaunayMap, startDart = None, cs = None):
            not startDart.leftFace().flag(OUTER_FACE), \
            "expecting startDart to be on the shape's contour," \
            "with the inner triangles on the left"
-    
+
     if not cs:
         cs = calculateChordStrengths(delaunayMap)
 
@@ -625,7 +653,7 @@ def catMap(delaunayMap,
 
     If you want to use the rectified CAT (with weak chords being
     suppressed), you would use removeWeakChords before calling catMap:
-    
+
     >>> del2 = copy.copy(del1) # if you want to keep the original
     >>> removeWeakChords(del2)
     >>> rcat2 = delaunay.catMap(del2)
@@ -684,10 +712,10 @@ def catMap(delaunayMap,
                 chords.append(dart)
             else:
                 bl += dart.edge().length()
-        
+
         boundaryLength[face.label()] = bl
         faceChords[face.label()] = chords
-        
+
         # classify into terminal, sleeve, and junction triangles:
         if len(chords) < 2:
             faceType[face.label()] = "T"
@@ -707,7 +735,7 @@ def catMap(delaunayMap,
     for face in delaunayMap.faceIter(skipInfinite = True):
         if face.flag(OUTER_FACE):
             continue
-        
+
         if faceType[face.label()] != "S":
             #print faceType[face.label()] + "-triangle", face.label()
             for dart in faceChords[face.label()]:
@@ -767,7 +795,7 @@ def catMap(delaunayMap,
                     nodeLabel[nextFace.label()] = nodeLabel[face.label()]
                     result.removeIsolatedNode(endNode)
                     continue
-                
+
                 sleeve = result.addEdge(
                     startNode, endNode, edgePoints)
                 sleeve.setFlag(flags)
@@ -933,7 +961,7 @@ def pruneBySubtendedLength(skelMap, delaunayMap = None,
       pruneBySubtendedLength(catMap, delMap, minLength = 3)
       pruneBySubtendedLength(catMap, delMap, ratio = 0.02)
       pruneBySubtendedLength(catMap) # use default: 1%"""
-    
+
     changed = True
     result = 0
 
@@ -966,7 +994,7 @@ def pruneBySubtendedLength(skelMap, delaunayMap = None,
         subtendedBoundaryLength = skelMap.subtendedLengths[edge.label()]
         if subtendedBoundaryLength >= minLength:
             continue
-        
+
         dart = edge.dart()
         if dart.startNode().hasMinDegree(2):
             dart.nextAlpha()
@@ -982,7 +1010,7 @@ def pruneBySubtendedLength(skelMap, delaunayMap = None,
             continue
 
         # (dart now belongs to a barb, startNode().degree() == 1)
-        
+
         neighbor = dart.clone().nextPhi()
         skelMap.subtendedLengths[neighbor.edgeLabel()] \
             += subtendedBoundaryLength
@@ -999,7 +1027,7 @@ def pruneBySubtendedLength(skelMap, delaunayMap = None,
                     del chordLabels[i]
                     break
             assert sleeve == dart.edgeLabel()
-            
+
             if delaunayMap and dart.endNode().hasMinDegree(3):
                 dart.endNode().setPosition(
                     rectifiedJunctionNodePosition(
@@ -1048,7 +1076,7 @@ def circumCircle(p1, p2, p3):
 
     Returns the center and radius of the circumcircle of the given
     three points."""
-    
+
     p1sm = squaredNorm(p1)
     x1 = p1[0]
     y1 = p1[1]
@@ -1099,7 +1127,7 @@ def calculateTriangleCircumcircles(delaunayMap):
     Returns a list of circumcircles for each face in the delaunayMap
     (with the face labels as indices).  Entries for faces marked with
     the OUTER_FACE flag are set to None."""
-    
+
     result = [None] * delaunayMap.maxFaceLabel()
     for triangle in delaunayMap.faceIter(skipInfinite = True):
         if triangle.flag(OUTER_FACE):

--- a/python/applications/dsl.py
+++ b/python/applications/dsl.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import copy
 from vigra import Point2D, Vector2, Rational, sq
 
@@ -7,14 +35,14 @@ def freeman(crackEdge):
     Returns freeman codes for each polyline segment in the given
     crackEdge polygon.  Uses mathematical orientation, i.e. the code
     meaning is:
-    
+
     0: diff = ( 1,  0)
     1: diff = ( 0,  1)
     2: diff = (-1,  0)
     3: diff = ( 0, -1)
 
     Effect unspecified if crackEdge is not a crack edge polygon."""
-    
+
     result = [None] * (len(crackEdge)-1)
     it = iter(crackEdge)
     prev = it.next()
@@ -125,44 +153,44 @@ class PyDigitalStraightLine(object):
         self.b = b
         self.pos = pos
         self.is8Connected = True
-    
+
     def slope(self):
         return Rational(self.a, self.b)
-    
+
     def axisIntercept(self, leaningType = 0):
         """dsl.axisIntercept(leaningType = 0)
-        
+
         leaningType means:
         0: center line
         1: lower leaning line
         2: upper leaning line"""
-        
+
         pos = Rational(self.pos, 1)
         if leaningType == 0:
             pos += Rational(self.width()-1, 2)
         elif leaningType == 1:
             pos += self.width()-1
         return -pos / self.b
-    
+
     def __call__(self, x, y):
         return self.a*x - self.b*y
-    
+
     def __getinitargs__(self):
         return (self.a, self.b, self.pos)
-    
+
     def contains(self, x, y):
         v = self(x, y) - self.pos
         return 0 <= v < self.width()
-    
+
     def width(self):
         if self.is8Connected:
             return max(abs(self.a), abs(self.b))
         else:
             return abs(self.a) + abs(self.b)
-    
+
     def __repr__(self):
         return "PyDigitalStraightLine(%d, %d, %d)" % (self.a, self.b, self.pos)
-    
+
     def addPoint(self, x, y):
         """works only for 8-connected lines in 1st octant"""
         assert self.is8Connected and (0 <= self.a <= self.b)
@@ -172,7 +200,7 @@ class PyDigitalStraightLine(object):
         if 0 <= v < width:
             #print "point already inside:", self, point
             return True # point is within DSL
-        
+
         above = True
         if v == -1:
             #print "point above"
@@ -221,7 +249,7 @@ class PyDigitalStraightLine(object):
         else:
             # ensure new point is on upper leaning line:
             self.pos = self(x, y) - self.width() + 1
-        
+
         if not self.contains(x, y):
             #print self, v, point
             assert self.contains(x, y), \
@@ -232,14 +260,14 @@ class PyDigitalStraightLine(object):
 
     def mirrorX(self):
         self.a = -self.a
-    
+
     def mirrorY(self):
         self.mirrorX()
         self.mirrorXY()
-    
+
     def mirrorXY(self):
         self.pos = 1-self.width()-self.pos
-    
+
     def convertToFourConnected(self):
         assert self.is8Connected, "DSL should not be converted twice"
         self.b = self.b - self.a
@@ -349,7 +377,7 @@ def crackEdgeTangent(freemanCodes, pointIndex, closed):
     dsl, ofs = geomap.tangentDSL(freemanCodes, pointIndex, closed)
     if not ofs:
         return dsl, ofs
-    
+
     dsl = dsl.convertToFourConnected()
 
     fc1 = freemanCodes[pointIndex - ofs]
@@ -358,7 +386,7 @@ def crackEdgeTangent(freemanCodes, pointIndex, closed):
         fc2 = freemanCodes[crackIndex % count]
         if fc2 != fc1:
             break
-    
+
     q = quadrant(fc1, fc2)
     if q == 0:
         pass
@@ -375,7 +403,7 @@ def quadrant(fc1, fc2):
 
     Given the two different freeman codes fc1 and fc2, returns the
     number of the respective quadrant."""
-    
+
     if fc2 < fc1:
         fc1, fc2 = fc2, fc1
     if fc1 > 0:
@@ -416,7 +444,7 @@ def offset2(freemanCodes, pointIndex, closed = True):
     results.  The RMSE of the points' radii in the circle example from
     __main__ is 0.4 percent lower, so this is the default / used in
     euclideanPath. ;-)"""
-    
+
     if closed:
         pointIndex = pointIndex % len(freemanCodes)
 
@@ -467,7 +495,7 @@ class DSLExperiment(object):
         self.code1 = None
         self.code2 = None
         self.freeman2Diff = reverse and freeman2Diff8ConnThirdQuadrant or freeman2Diff8ConnFirstQuadrant
-    
+
     def __call__(self, code, plot = True):
         if self.dsl == None:
             self.dsl = DigitalStraightLine(code % 2 and 1 or 0, 1, 0)
@@ -482,7 +510,7 @@ class DSLExperiment(object):
             self.points.append(newPos)
             return self.plot(plot)
         return False
-    
+
     def plot(self, plot = True):
         result = True
         for point in self.points:
@@ -502,7 +530,7 @@ if __name__ == "__main__":
     dsl.addPoint(-2, -1)
 
     from vigra import GrayImage, norm, meshIter
-    
+
     gimg = GrayImage(50, 50)
     for p in meshIter(gimg.size()):
         gimg[p] = norm(p - Point2D(25, 25)) < 20 and 255 or 0

--- a/python/applications/koch.py
+++ b/python/applications/koch.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import math
 from vigra import Vector2
 from geomap import Polygon

--- a/python/applications/levelcontours.py
+++ b/python/applications/levelcontours.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import sys, copy
 import numpy, vigra, geomap, maputils, flag_constants, progress
 from geomap import Vector2, Point2D
@@ -23,7 +51,7 @@ def findZeroCrossingsOnGrid(siv, level, minDist = 0.1):
         if not existing(p, minDist2):
             result.append(p)
             existing.insert(p, True)
-    
+
     for y in range(siv.height()-1):
         for x in range(siv.width()-1):
             coeff = siv.coefficients(x, y)
@@ -61,14 +89,14 @@ def predictorStep(siv, pos, h):
     Step distance h from pos in direction of tangent (perpendicular
     to gradient).  Returns None if that point is outside the
     SplineImageView."""
-    
+
     return pos + h*tangentDir(siv, pos)
 
 def correctorStep(siv, level, pos, epsilon = 1e-8):
     """Perform corrector step, i.e. perform 1D iterative Newton method in
     direction of gradient in order to return to zero level (with
     accuracy given by epsilon)."""
-    
+
     x, y = pos
     n = Vector2(siv.dx(x, y), siv.dy(x, y))
     n /= numpy.linalg.norm(n)
@@ -77,7 +105,7 @@ def correctorStep(siv, level, pos, epsilon = 1e-8):
         value = siv(x, y) - level
         if abs(value) < epsilon:
             break
-        
+
         g = numpy.dot(Vector2(siv.dx(x, y), siv.dy(x, y)), n)
         if not g:
             sys.stderr.write("WARNING: correctorStep: zero gradient!\n")
@@ -90,7 +118,7 @@ def correctorStep(siv, level, pos, epsilon = 1e-8):
 
         x += correction[0]
         y += correction[1]
-        
+
         if not siv.isInside(x, y):
             return None # out of range
 
@@ -120,7 +148,7 @@ def predictorCorrectorStep(siv, level, pos, h, epsilon):
 def followContour(siv, level, geomap, nodeLabel, h):
     correctorEpsilon = 1e-6
     nodeCrossingDist = 0.01
-    
+
     #global pos, ip, poly, startNode, diff, npos, nip, intersection
     startNode = geomap.node(nodeLabel)
     pos = startNode.position()
@@ -166,7 +194,7 @@ def followContour(siv, level, geomap, nodeLabel, h):
 
 def levelSetMap(image, level = 0, sigma = None):
     siv = hasattr(image, "siv") and image.siv or vigra.SplineImageView3(image)
-    
+
     zc = findZeroCrossingsOnGrid(siv, level)
     result = geomap.GeoMap(zc, [], image.size())
 
@@ -187,7 +215,7 @@ def levelSetMap(image, level = 0, sigma = None):
     result.sortEdgesEventually(0.4, 0.01)
     result.initializeMap()
     return result
-    
+
 # --------------------------------------------------------------------
 
 def marchingSquares(image, level = 0, variant = True, border = True,
@@ -220,13 +248,13 @@ def marchingSquares(image, level = 0, variant = True, border = True,
     If markOuter is != 0, the faces above(outer == 1) / below(outer == -1)
     the threshold are marked with the OUTER_FACE flag (this only works
     if the map is initialized)."""
-    
+
     connections1 = ((1, 0), (0, 2), (1, 2), (3, 1), (3, 0), (0, 2), (3, 1), (3, 2), (2, 3), (1, 0), (2, 3), (0, 3), (1, 3), (2, 1), (2, 0), (0, 1))
     connections2 = ((1, 0), (0, 2), (1, 2), (3, 1), (3, 0), (0, 1), (3, 2), (3, 2), (2, 3), (1, 3), (2, 0), (0, 3), (1, 3), (2, 1), (2, 0), (0, 1))
     configurations = (0, 0, 1, 2, 3, 4, 5, 7, 8, 9, 11, 12, 13, 14, 15, 16, 16)
 
     result = geomap.GeoMap(image.shape)
-    
+
     def addNodeDirectX(x, y, ofs):
         pos = Vector2(x+ofs, y)
         # out of three successive pixels, the middle one may be the

--- a/python/applications/pixelmap.py
+++ b/python/applications/pixelmap.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import vigra, geomap, crackConvert
 import cellimage
 from geomap import Vector2, Size2D, Point2D, Rect2D
@@ -86,7 +114,7 @@ def pixelMap2subPixelMap(pixelMap, scale = 1.0, offset = Vector2(0, 0),
             endNeighbor = edges[neighbor.edgeLabel()].dart()
             if neighbor == neighbor.edge().end:
                 endNeighbor.nextAlpha()
-                
+
         newEdge = result.addEdge(startNeighbor, endNeighbor, points)
         edges[edge.label] = newEdge
 
@@ -116,7 +144,7 @@ def crackEdges2MidCracks(subpixelMap):
 
     Note that this is done in a brutal way; the resulting map will
     fail checkConsistency()."""
-    
+
     for edge in subpixelMap.edgeIter():
         p = geomap.Polygon()
         p.append(edge[0])
@@ -131,7 +159,7 @@ def cannyEdgeMap(image, scale, thresh):
     Returns a subpixel-GeoMap object containing thinned canny edges
     obtained from cannyEdgeImage(image, scale, thresh).
     (Internally creates a pixel GeoMap first.)"""
-    
+
     edgeImage = vigra.analysis.cannyEdgeImageWithThinning(image, scale, thresh, 1)
     pixelMap = cellimage.GeoMap(edgeImage, 0, cellimage.CellType.Line)
     spmap = pixelMap2subPixelMap(
@@ -174,7 +202,7 @@ def pixelWatershedMap(biImage, crackEdges = 4, midCracks = False):
     If midCracks is True, the resulting edges consist of the
     connected midpoints of the cracks, not of the crack segments
     themselves (this parameter is ignored if crackEdges == 0)."""
-    
+
     if crackEdges:
         print "- Union-Find watershed segmentation..."
         lab, count = getattr(vigra, 'watershedUnionFind' + str(crackEdges))(biImage)

--- a/python/gui/darthighlighter.py
+++ b/python/gui/darthighlighter.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import sys
 from weakref import ref
 from PyQt4 import QtCore, QtGui
@@ -6,7 +34,7 @@ import VigraQt
 class DartHighlighter(VigraQt.Overlay):
     """The DartHighlighter class is attached to a viewer and a Map and
     is able to highlight any set of darts at a time."""
-    
+
     def __init__(self, map, viewer):
         VigraQt.Overlay.__init__(self, viewer)
         self._map = ref(map)

--- a/python/gui/dartnavigator.py
+++ b/python/gui/dartnavigator.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 from darthighlighter import DartHighlighter
 
 # ui-generated base classes:
@@ -6,7 +34,7 @@ from PyQt4 import QtCore, QtGui
 
 class DartNavigator(QtGui.QDialog):
     __base = QtGui.QDialog
-    
+
     def __init__(self, dart, costMeasure, parent, name = None):
         self.__base.__init__(self, parent)
         if name:

--- a/python/gui/figexport.py
+++ b/python/gui/figexport.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import os, sys, fig, math
 from PyQt4 import QtCore, QtGui
 
@@ -41,7 +69,7 @@ class FigExporter:
 
     For a discussion of the scaling/clipping, see documentation of
     __init__()."""
-    
+
     def __init__(self, scale = 30, roi = None, offset = (0.5, 0.5)):
         """fe = FigExporter(90.0, BoundingBox((10, 10), (50, 50)))
 
@@ -62,7 +90,7 @@ class FigExporter:
         The transformation parameters are stored as properties scale,
         roi, and offset, and these settings can be queried or even
         changed at any time (between adding objects)."""
-        
+
         self.f = fig.File()
         self.scale = scale
         self.roi = roi
@@ -95,7 +123,7 @@ class FigExporter:
         Adds a rectangle around the given roi (ignoring fe.offset).
         If roi == None (default), the roi of the FigExporter itself is used.
         The fig.PolyBox object is returned."""
-        
+
         assert roi or self.roi, "addROIRect(): no ROI given!?"
 
         if container == True:
@@ -150,7 +178,7 @@ class FigExporter:
         BoundingBox positioned at the origin.
 
         Returns the pair (bgImage, bgRect) of both added fig objects."""
-        
+
         if not params.has_key("roi") and not self.roi:
             size = readImage(bgImageFilename).size()
             params["roi"] = Rect2D(size)
@@ -159,7 +187,7 @@ class FigExporter:
 
         if not params.has_key("depth"):
             params["depth"] = 1
-        
+
         bgRect = self.addROIRect(**params)
 
         bgImage = fig.PictureBBox(0, 0, 1, 1, bgImageFilename)
@@ -177,7 +205,7 @@ class FigExporter:
         parameter), the image file is opened (using readImage) and its
         size is used to initialize a BoundingBox positioned at the
         origin.  Returns the fig.PictureBBox object."""
-        
+
         bgImage, bgRect = self.addBackgroundWithFrame(
             filename, container, **params)
         if container == True:
@@ -190,18 +218,18 @@ class FigExporter:
                        container = True, labelType = int, **attr):
         """The default label size looks good with 1cm^2 pixels
         (scale = 450)."""
-        
+
         assert rect or labels or fill
         if rect is None:
             rect = Rect2D((labels or fill).size())
         elif not hasattr(rect, "upperLeft"):
             w, h = rect
             rect = Rect2D((w, h))
-        
+
         if container == True:
             container = self.f
         result = fig.Compound(container)
-        
+
         for x, y in meshIter(rect):
             boxX1 = (x - rect.left()) * self.scale
             boxY1 = (y - rect.top()) * self.scale
@@ -228,7 +256,7 @@ class FigExporter:
             if fill:
                 pixelRect.fillStyle = fig.FillStyle.Solid
                 pixelRect.fillColor = self.f.getColor(int(fill[x, y]))
-                    
+
             result.append(pixelRect)
         return result
 
@@ -254,7 +282,7 @@ class FigExporter:
         is called on the *scaled* polygon (i.e. the default is to
         simplify the polygon to 0.5 fig units, which are integer
         anyways)."""
-        
+
         if container == True:
             container = self.f
         o = self.offset + attr.get('offset', (0,0))
@@ -326,17 +354,17 @@ class FigExporter:
         of setting properties (depth, penColor, lineStyle, lineWidth,
         ...) on all resulting objects via keyword arguments
         (cf. documentation of the FigExporter class).
-        
+
         By default, circles will be filled, but have lineWidth=0.
         To draw a transparent circle, call:
-        
+
         fi.addPointCircles([(5.2,5.3)], 2, penColor=fig.Color.Cyan,fillStyle=fig.FillStyle.None,lineWidth=1)
 
         If returnIndices is set to True (default: False), a list of
         (i, c) pairs is returned instead, where c is the fig.Circle
         object, and i is the index of the corresponding position in
         points."""
-        
+
         if container == True:
             container = self.f
 
@@ -414,7 +442,7 @@ class FigExporter:
         """See addPointCircles(), this function simply takes the
         points and radius from a PointOverlay object for your
         convenience."""
-        
+
         points = pointOverlay.originalPoints
         radius = float(pointOverlay.origRadius)
         if not pointOverlay.relativeRadius:
@@ -423,7 +451,7 @@ class FigExporter:
         attr = dict(attr)
         self._setOverlayColor(pointOverlay, "fillColor", attr)
         attr["lineWidth"] = attr.get("lineWidth", 0)
-        
+
         return self.addPointCircles(points, radius, container = container, **attr)
 
     def addEdgeOverlay(self, edgeOverlay, container = True, **attr):
@@ -455,7 +483,7 @@ class FigExporter:
         circles = circleOverlay.originalCircles
         attr = dict(attr)
         self._setOverlayColor(circleOverlay, "penColor", attr)
-            
+
         o = self.offset + attr.get('offset', (0,0))
         if self.roi:
             o = o - self.roi.begin() # don't modify in-place!
@@ -482,7 +510,7 @@ class FigExporter:
         If the optional parameter returnNodes is set to True, a list
         of (node, circleObject) pairs is returned, similar to the
         returnIndices parameter of addPointCircles()."""
-        
+
         points = [node.position() for node in map.nodeIter()]
         result = self.addPointCircles(
             points, radius, returnIndices = returnNodes, container = container, **attr)
@@ -497,13 +525,13 @@ class FigExporter:
         see addClippedPoly).  If no penColor is given, only edges with
         a valid 'color' attribute are exported (can be either a fig or
         a Qt color).
-        
+
         For example, to draw only a subregion, and shift the upper left of
         the region to the origin, call
-        
+
         fi.addMapEdges(map, penColor=fig.Color.Green, \
              offset=(-13,-13), roi=BoundingBox((13,13), (24,24)))
-        
+
         """
 
         if container == True:
@@ -663,7 +691,7 @@ def exportImageWindow(
     Overlays are saved using the given overlayHandler.  The default
     handler (addStandardOverlay) can handle the standard vigrapyqt4
     point, edge, and circle overlays."""
-    
+
     figFilename = basepath + ".fig"
     pngFilename = basepath + "_bg.png"
 
@@ -676,7 +704,7 @@ def exportImageWindow(
         roi = Rect2D(*roi)
     elif type(roi) == str:
         roi = Rect2D(*fig.parseGeometry(roi))
-    
+
     if bgFilename == None:
         # create .png background
         image, normalize = w.getDisplay()

--- a/python/gui/icons.py
+++ b/python/gui/icons.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 reinitIconPNGData = \
     "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d" \
     "\x49\x48\x44\x52\x00\x00\x00\x16\x00\x00\x00\x16" \

--- a/python/gui/mapdisplay.py
+++ b/python/gui/mapdisplay.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import sys, math
 import fig, figexport
 import vigra, vigra.pyqt
@@ -57,7 +85,7 @@ class _py_MapFaces(VigraQt.Overlay):
         `face` may be an int, an Face object, or a tuple/list
         of one of the two.  (Passing multiple faces results in only
         one call to viewer.update(ROI).)"""
-        
+
         if isinstance(face, (tuple, list)):
             roi = QtCore.QRect()
             for face in face:
@@ -97,7 +125,7 @@ class _py_MapFaces(VigraQt.Overlay):
 
     def setZoom(self, zoom):
         pass # zoom is managed via self.edgeOverlay
-    
+
     def draw(self, p, rect):
         if not self._map():
             return
@@ -150,7 +178,7 @@ class _py_MapEdges(VigraQt.Overlay):
                  "_zoom", "_zoomedEdges")
 
     __base = VigraQt.Overlay
-    
+
     def __init__(self, viewer, map, color, width = 0,
                  protectedColor = None, protectedWidth = None):
         self.__base.__init__(self, viewer)
@@ -191,7 +219,7 @@ class _py_MapEdges(VigraQt.Overlay):
         viewer.  `edge` may be an int, an Edge object, or a tuple/list
         of one of the two.  (Passing multiple edges results in only
         one call to viewer.update(ROI).)"""
-        
+
         if not self.colors:
             self.colors = [self.color] * self._map().maxEdgeLabel()
 
@@ -218,7 +246,7 @@ class _py_MapEdges(VigraQt.Overlay):
         `edge` may be an int, an Edge object, or a tuple/list
         of one of the two.  (Passing multiple edges results in only
         one call to viewer.update(ROI).)"""
-        
+
         if isinstance(edge, (tuple, list)):
             roi = QtCore.QRect()
             for edge in edge:
@@ -309,7 +337,7 @@ class _py_MapEdges(VigraQt.Overlay):
         if result == None:
             result = self._calculateZoomedEdge(index, edge)
         return result
-    
+
     def draw(self, p, rect = None):
         if not self._map():
             return
@@ -348,7 +376,7 @@ class _py_MapEdges(VigraQt.Overlay):
 
 class MapNodes(VigraQt.Overlay):
     __base = VigraQt.Overlay
-    
+
     def __init__(self, map, color, radius = 0.2, relativeRadius = True):
         self.__base.__init__(self, color = color)
         self.setMap(map)
@@ -420,7 +448,7 @@ class MapNodes(VigraQt.Overlay):
         * display pixels if relativeRadius == False
         * image pixels   if relativeRadius == True
         """
-        
+
         self.origRadius = radius
         self.radius = radius
         self.relativeRadius = relativeRadius
@@ -549,7 +577,7 @@ class MapDisplay(QtGui.QMainWindow):
                  "_togglingGUI", "_backgroundMode", "_normalizeStates",
                  "_faceMeans", "_attachedHooks",
                  "dn", "_dh")
-    
+
     def __init__(self, map, preparedImage = None, immediateShow = True,
                  faceMeans = None):
         self.__base.__init__(self)
@@ -773,7 +801,7 @@ class MapDisplay(QtGui.QMainWindow):
             for h in self._attachedHooks:
                 h.disconnect()
             self._attachedHooks = None
-            
+
             if results == (True, True):
                 return True
         else:
@@ -986,7 +1014,7 @@ class MapDisplay(QtGui.QMainWindow):
             self.viewer, basepath, roi = roi, scale = scale,
             bgFilename = bgFilename,
             overlayHandler = overlayHandler)
-        
+
         if faceMeans in (None, True):
             faceMeans = self._faceMeans
 
@@ -994,7 +1022,7 @@ class MapDisplay(QtGui.QMainWindow):
             fe.addMapFaces(
                 self.map, faceMeans, similarity, depth = 900)
             fe.f.save()
-        
+
         return fe
 
     def saveEPS(self, basepath, *args, **kwargs):

--- a/python/interactive/qimageviewertool.py
+++ b/python/interactive/qimageviewertool.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 from PyQt4 import QtCore
 
 class QImageViewerTool(QtCore.QObject):

--- a/python/interactive/roiselector.py
+++ b/python/interactive/roiselector.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import copy
 from PyQt4 import QtCore, QtGui
 from geomap import intPos, Rect2D

--- a/python/interactive/tools.py
+++ b/python/interactive/tools.py
@@ -1,5 +1,34 @@
 """tools - module with interactive GeoMap tools"""
 
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
+
 import sys
 from PyQt4 import QtCore, QtGui
 import geomap, maputils
@@ -63,7 +92,7 @@ class ManualClassifier(QImageViewerTool):
     Faces can be clicked to toggle their class (LMB/MMB for
     forward/backward cycling through classes), or strokes can be used
     to transfer the class of a face to its neighbors."""
-    
+
     __slots__ = ("manual",
                  "_map", "_classes", "_classMask", "_overlays",
                  "_enabled", "_pressed",
@@ -273,7 +302,7 @@ class SeedSelector(QImageViewerTool):
             self.emit(QtCore.SIGNAL("seedRemoved"), seed)
             if self.map and self.markFlags:
                 self.map.faceAt((x, y)).setFlag(self.markFlags, False)
-        
+
         self.overlay.setPoints(self.seeds)
         viewer.update()
         return True
@@ -368,7 +397,7 @@ from flag_constants import CURRENT_CONTOUR, SCISSOR_PROTECTION, BORDER_PROTECTIO
 
 class LiveWire(object):
     """Represents a live wire path and manages path search.
-    
+
     The LiveWire class does not only represent a single live wire
     path, but also performs the complete path search in a dynamic
     programming fashion, i.e. finding the optimal paths to all
@@ -490,7 +519,7 @@ class LiveWire(object):
         `nodeLabel` (i.e. pathDarts(nodeLabel)) passes endNodeLabel,
         return this (e.g. loop closing) path segment, else return
         None. """
-        
+
         if self._nodePaths[nodeLabel]:
             result = []
             for dart in self.pathDarts(nodeLabel):
@@ -565,7 +594,7 @@ class IntelligentScissors(QImageViewerTool):
     def stopCurrentContour(self):
         """Called when the current contour is stopped, e.g. with
         middle MB (cancel) or with a LMB double click (confirm)."""
-        
+
         self.stopLiveWire()
 
         #updateViewer(self.currentPathBounds)
@@ -605,7 +634,7 @@ class IntelligentScissors(QImageViewerTool):
                 self.stopLiveWire()
                 self._protectPath(self._liveWire.pathDarts())
                 self._startNodeLabel = self._liveWire.endNodeLabel()
-        
+
         o = EdgeOverlay([], QtCore.Qt.yellow, 2)
         self._viewer.replaceOverlay(o, self._overlay)
         self._overlay = o

--- a/python/interactive/workspace.py
+++ b/python/interactive/workspace.py
@@ -7,6 +7,35 @@ COMMANDLINE USAGE:
 
 workspace.py <image_filename> [gauss_sigma] [saddle_threshold]
 """
+
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import copy, sys
 from PyQt4 import QtCore, QtGui
 import vigra, geomap
@@ -38,10 +67,10 @@ class PyramidContractionKernel(statistics.DetachableStatistics):
     """Represents a merge tree annotated with the number of remaining
     faces.  Thus, it can be used to compute a contraction kernel that
     encodes all merges up to a specific pyramid level / face count."""
-    
+
     __base = statistics.DetachableStatistics
     __slots__ = ("ck", "_mergedFaceLabels")
-    
+
     def __init__(self, map):
         self.__base.__init__(self, map)
         self.ck = [None] * map.maxFaceLabel()
@@ -147,7 +176,7 @@ class ScissorsProtection(object):
         self.workspace = workspace
         self.contour = []
         #self.closed # see TODO below
-        
+
         level0 = workspace._level0
         mergedEdges = workspace.map.mergedEdges
         for dart in contour:
@@ -201,7 +230,7 @@ class Workspace(mapdisplay.MapDisplay):
                  "_mapRestartAction", "_levelSlider",
                  "_manualBaseMapFaceCount", "_estimatedApexFaceCount",
                  "_history", "_activeTool", "colorSpace")
-    
+
     def __init__(self, level0, originalImage, bi = None):
         self.__base.__init__(self, copy.deepcopy(level0), originalImage)
         self._level0 = level0
@@ -250,7 +279,7 @@ class Workspace(mapdisplay.MapDisplay):
         l.addWidget(cmChooser)
         cml.setBuddy(cmChooser)
         self._cmChooser = cmChooser
-        
+
         csl = QtGui.QLabel("C&olor space:", automaticOptions)
         l.addWidget(csl)
         csChooser = QtGui.QComboBox(automaticOptions)
@@ -266,7 +295,7 @@ class Workspace(mapdisplay.MapDisplay):
         self.dynamicCheckBox.setChecked(self.dynamicCosts)
         self.connect(self.dynamicCheckBox, QtCore.SIGNAL("toggled(bool)"),
                      self.setDynamicCosts)
-        
+
         l.addItem(QtGui.QSpacerItem(
             10, 1, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum))
         self._imageWindow._layout.insertWidget(0, automaticOptions)

--- a/python/maputils/crackConvert.py
+++ b/python/maputils/crackConvert.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import sys, time, copy
 from geomap import GeoMap, crackConnectionImage, crackEdgeGraph
 import vigra
@@ -16,7 +44,7 @@ def crackEdgeMap(labelImage, initLabelImage = True,
     result = crackEdgeGraph(labelImage, eightConnectedRegions = eightConnectedRegions)
     result.sortEdgesDirectly()
     result.initializeMap(initLabelImage)
-    
+
     # mark the border edges:
     assert result.face(0).holeCount() == 1, "infinite face should have exactly one contour, not %d!?" % result.face(0).holeCount()
     for dart in result.face(0).holeContours().next().phiOrbit():
@@ -152,7 +180,7 @@ def followEdge(crackConnectionImage, pos, direction):
 
             if not connection & CONN_ALL4:
                 connection &= ~CONN_MAYBE_NODE
-                
+
             crackConnectionImage[pos] = connection
             continue
         elif connection & CONN_NODE:
@@ -201,7 +229,7 @@ def pyCrackEdgeGraph(labelImage, eightConnectedRegions = True,
                 cc[x,y] = conn | CONN_MAYBE_NODE
             if conn & CONN_DIAG:
                 cc[x,y] = conn | CONN_MAYBE_NODE
-    
+
     nodeImage = ScalarImage(cc.size())
     # nodeImage encoding: each pixel's higher 28 bits encode the
     # (label + 1) of a node that has been inserted into the resulting

--- a/python/maputils/dartpath.py
+++ b/python/maputils/dartpath.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 from geomap import composeTangentLists, Polygon
 
 class Path(list):
@@ -12,7 +40,7 @@ class Path(list):
         Reverses a path represented as a list of Dart objects.
         (list.reverse() is called and all darts are switched with
         nextAlpha().)"""
-        
+
         for dart in self:
             dart.nextAlpha()
         super(Path, self).reverse()
@@ -35,7 +63,7 @@ class Path(list):
         Returns an iterator over all points in this path.
         (Skipping the first points of all darts except the first,
         since they are supposed to be duplicates.)"""
-        
+
         yield self[0][0]
         for dart in self:
             pit = iter(dart); pit.next() # skip first point
@@ -138,9 +166,9 @@ def allContinuations(startDart, length, klass = Path):
 
     Returns a list of Path objects representing all possible paths of
     the given length (number of darts) starting with the given dart that
-    
+
     * do not contain an edge with BORDER_PROTECTION and
-    
+
     * do not contain a direct pair of opposite darts
       (i.e. loops are allowed, but no "U-turns").
 

--- a/python/maputils/flag_constants.py
+++ b/python/maputils/flag_constants.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 # --------------------------------------------------------------------
 #                             edge flags
 # --------------------------------------------------------------------

--- a/python/maputils/polytools.py
+++ b/python/maputils/polytools.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import vigra, geomap, numpy, math
 from geomap import Polygon
 
@@ -26,7 +54,7 @@ def maxDistIter(polygon, maxDist):
             for i in range(1, segmentCount):
                 yield p + segment*i/segmentCount
         yield p
-        
+
 # --------------------------------------------------------------------
 
 LEFT = 1
@@ -42,7 +70,7 @@ def clipPoly(polygon, clipRect, closeAtBorder = None):
     enter again, leave, ...).  Polygon segments crossing clipRect's
     borders are cut, such that the resulting polyons get new endpoints
     exactly on the border."""
-    
+
     result = []
 
 #     print "clipPoly(%s..%s)" % (clipRect.begin(), clipRect.end())
@@ -212,7 +240,7 @@ def clipPoly(polygon, clipRect, closeAtBorder = None):
                 break
             poly = result
         return result
-    
+
     lastPoly = None
     prevPoly = None
     prevOutside = None
@@ -254,7 +282,7 @@ class Line(object):
 
     def isParallel(self, other):
         return abs(numpy.dot(self.norm, other.norm)) == 1.0
-    
+
     def intersect(self, other):
         assert not self.isParallel(other)
         if abs(self.norm[0]) > abs(other.norm[0]):
@@ -284,20 +312,20 @@ class LineSegment(object):
     def __init__(self, p1, p2):
         self.p1 = p1
         self.p2 = p2
-    
+
     def dir(self):
         result = self.p2 - self.p1
         result /= result.magnitude()
         return result
-    
+
     def norm(self):
         d = self.dir()
         return (-d[1], d[0])
-    
+
     def dist(self):
         """distance to origin"""
         return numpy.dot(self.p1, self.norm())
-    
+
     def line(self):
         return Line(self.norm(), self.dist())
 
@@ -328,7 +356,7 @@ def shrinkPoly(poly, offset):
 
 def rotatePoly(poly, angle):
     """Rotate polygon by the given angle around the origin."""
-    
+
     unitX = (math.cos(angle), -math.sin(angle))
     unitY = (math.sin(angle),  math.cos(angle))
     result = Polygon()

--- a/python/test/test_cellimage.py
+++ b/python/test/test_cellimage.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import vigra, numpy, cellimage
 
 def map_from_boundaries(boundaries_filename, cornerType = cellimage.CellType.Line):

--- a/python/test/test_spws.py
+++ b/python/test/test_spws.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 #from vigra import labelImage4
 from geomap import Polygon
 import maputils

--- a/python/utils/bi_utils.py
+++ b/python/utils/bi_utils.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import vigra
 
 def tensor2Gradient(tensor):
@@ -18,7 +46,7 @@ def gaussianHessian(image, sigma):
 def gm2Gradient(gm, sigma):
     """'reverse-engineer' gradient vector image from scalar image
     via Hessian from Gaussian derivative filters of given scale"""
-    
+
     # create vectors in direction of negative curvature:
     er = vigra.tensorEigenRepresentation(
         vigra.gaussianHessian(gm, sigma))
@@ -28,12 +56,12 @@ def gm2Gradient(gm, sigma):
 def gradientTensor(img, scale):
     """Returns a 3-band image with gradient tensor summed over all
     bands.  For single-band images, this is equivalent to::
-    
+
       vigra.filters.vectorToTensor(
           vigra.filters.gaussianGradient(img, scale)
 
     (Otherwise, it is the sum of the same for all bands.)"""
-    
+
     bandTensors = [
         vigra.filters.vectorToTensor(
         vigra.filters.gaussianGradient(img.subImage(i), scale))
@@ -52,7 +80,7 @@ def colorGradient(img, scale, sqrt = True):
     If `sqrt` is set to False, returns (gm2, grad) instead, i.e. does
     not apply sqrt to the first image (slight optimization if you
     don't need the gm image)."""
-    
+
     colorTensor = gradientTensor(img, scale)
     # gm2 := sum of squared magnitudes of grad. in each channel
     gm2 = vigra.tensorTrace(colorTensor)
@@ -69,7 +97,7 @@ def gaussianGradient(img, scale, sqrt = True):
     """Return (gm, grad) tuple, which is either the result of
     `colorGradient`, or of the usual `vigra.gaussianGradient` family
     for single-band images."""
-    
+
     if img.channels > 1:
         return colorGradient(img, scale, sqrt)
 

--- a/python/utils/progress.py
+++ b/python/utils/progress.py
@@ -1,8 +1,36 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 class ProgressHook(object):
     """Represents a sub-progress range.  When called with a number
     between 0.0 and 1.0, calls the next hook with the scaled range.
     Sub-ranges can be created with subProgress."""
-    
+
     def __init__(self, hook, range = (0.0, 1.0)):
         self._start = range[0]
         self._end = range[1]

--- a/python/utils/sivtools.py
+++ b/python/utils/sivtools.py
@@ -1,4 +1,32 @@
 # -*- coding: iso-8859-1 -*-
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import vigra
 
 def sivByOrder(order):
@@ -28,7 +56,7 @@ class ThreeBandSIVProxy(object):
 class HessianSIVProxy(object):
     def __init__(self, siv):
         self.siv = siv
-    
+
     def __getitem__(self, pos):
         return geomap.Vector3(self.siv.dxx(pos[0], pos[1]),
                             self.siv.dxy(pos[0], pos[1]),

--- a/src/cellimage/cellconfigurations.hxx
+++ b/src/cellimage/cellconfigurations.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_CELLCONFIGURATIONS_HXX
 #define VIGRA_CELLCONFIGURATIONS_HXX
 

--- a/src/cellimage/cellimage.hxx
+++ b/src/cellimage/cellimage.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef CELLIMAGE_HXX
 #define CELLIMAGE_HXX
 
@@ -138,7 +166,7 @@ struct TypeLabelAccessor
         it->typeLabel_ = typeLabel;
     }
 };
-    
+
 template<CellType type>
 struct LabelWriter
 {

--- a/src/cellimage/cellimage_dart+info.cxx
+++ b/src/cellimage/cellimage_dart+info.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "foureightsegmentation.hxx"
 #include <boost/python.hpp>
 

--- a/src/cellimage/cellimage_edges.cxx
+++ b/src/cellimage/cellimage_edges.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "cellimage_module.hxx"
 
 using namespace vigra;

--- a/src/cellimage/cellimage_faces.cxx
+++ b/src/cellimage/cellimage_faces.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "cellimage_module.hxx"
 
 using namespace vigra;

--- a/src/cellimage/cellimage_module.cxx
+++ b/src/cellimage/cellimage_module.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "cellimage_module.hxx"
 #include <vigra/numpy_array.hxx>
 #include <boost/python/make_constructor.hpp>

--- a/src/cellimage/cellimage_module.hxx
+++ b/src/cellimage/cellimage_module.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef CELLIMAGE_MODULE_HXX
 #define CELLIMAGE_MODULE_HXX
 

--- a/src/cellimage/cellimage_nodes.cxx
+++ b/src/cellimage/cellimage_nodes.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "cellimage_module.hxx"
 
 using namespace vigra;

--- a/src/cellimage/cellimage_pyramid.cxx
+++ b/src/cellimage/cellimage_pyramid.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "cellimage_module.hxx"
 #include "cellstatistics.hxx"
 #define protected public

--- a/src/cellimage/cellpyramid.hxx
+++ b/src/cellimage/cellpyramid.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef CELLPYRAMID_HXX
 #define CELLPYRAMID_HXX
 

--- a/src/cellimage/cellstatistics.cxx
+++ b/src/cellimage/cellstatistics.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "cellstatistics.hxx"
 #include "crop.hxx"
 #include "debugimage.hxx"

--- a/src/cellimage/cellstatistics.hxx
+++ b/src/cellimage/cellstatistics.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef CELLSTATISTICS_HXX
 #define CELLSTATISTICS_HXX
 

--- a/src/cellimage/crop.hxx
+++ b/src/cellimage/crop.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef CROP_HXX
 #define CROP_HXX
 

--- a/src/cellimage/debugimage.hxx
+++ b/src/cellimage/debugimage.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_DEBUGIMAGE_HXX
 #define VIGRA_DEBUGIMAGE_HXX
 

--- a/src/cellimage/findsaddles.hxx
+++ b/src/cellimage/findsaddles.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_FINDSADDLES_HXX
 #define VIGRA_FINDSADDLES_HXX
 

--- a/src/cellimage/foureightsegmentation.cxx
+++ b/src/cellimage/foureightsegmentation.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "mydebug.hxx"
 #include "debugimage.hxx"
 #include "crop.hxx"

--- a/src/cellimage/foureightsegmentation.hxx
+++ b/src/cellimage/foureightsegmentation.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_GEOMAP_HXX
 #define VIGRA_GEOMAP_HXX
 

--- a/src/cellimage/gradient.hxx
+++ b/src/cellimage/gradient.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_GRADIENT_HXX
 #define VIGRA_GRADIENT_HXX
 

--- a/src/cellimage/hessematrix.hxx
+++ b/src/cellimage/hessematrix.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_HESSEMATRIX_HXX
 #define VIGRA_HESSEMATRIX_HXX
 

--- a/src/cellimage/imagefilteriterator.hxx
+++ b/src/cellimage/imagefilteriterator.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef IMAGEFILTERITERATOR_HXX
 #define IMAGEFILTERITERATOR_HXX
 

--- a/src/cellimage/mydebug.hxx
+++ b/src/cellimage/mydebug.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef MYDEBUG_HXX
 #define MYDEBUG_HXX
 

--- a/src/cellimage/neighborhoodcirculator.hxx
+++ b/src/cellimage/neighborhoodcirculator.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_NEIGHBORHOODCIRCULATOR_HXX
 #define VIGRA_NEIGHBORHOODCIRCULATOR_HXX
 

--- a/src/cellimage/statisticfunctor.hxx
+++ b/src/cellimage/statisticfunctor.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef STATISTICFUNCTOR_HXX
 #define STATISTICFUNCTOR_HXX
 

--- a/src/cellimage/test.cxx
+++ b/src/cellimage/test.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include <iostream>
 #include "unittest.hxx"
 #include "vigra/stdimage.hxx"

--- a/src/cellimage/testconfigurations.cxx
+++ b/src/cellimage/testconfigurations.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include <iostream>
 #include <string>
 #include "cellconfigurations.hxx"

--- a/src/cellimage/testfoureight.cxx
+++ b/src/cellimage/testfoureight.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include <iostream>
 #include <vigra/stdimage.hxx>
 #include <vigra/stdimagefunctions.hxx>

--- a/src/cellimage/testiterator.cxx
+++ b/src/cellimage/testiterator.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "filteriterator.hxx"
 #include <vigra/stdimagefunctions.hxx>
 #include <unittest.hxx>

--- a/src/cellimage/testrect.cxx
+++ b/src/cellimage/testrect.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include <vigra/diff2d.hxx>
 #include <unittest.hxx>
 #include <iostream>

--- a/src/geomap/cppmap.cxx
+++ b/src/geomap/cppmap.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "cppmap.hxx"
 #include <vigra/tinyvector.hxx>
 #include <vigra/multi_pointoperators.hxx>

--- a/src/geomap/cppmap.hxx
+++ b/src/geomap/cppmap.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_CPPMAP_HXX
 #define VIGRA_CPPMAP_HXX
 

--- a/src/geomap/cppmap_utils.cxx
+++ b/src/geomap/cppmap_utils.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "cppmap_utils.hxx"
 
 GeoMap::FacePtr mergeFacesCompletely(

--- a/src/geomap/cppmap_utils.hxx
+++ b/src/geomap/cppmap_utils.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef CPPMAP_UTILS_HXX
 #define CPPMAP_UTILS_HXX
 

--- a/src/geomap/crackedgemap.cxx
+++ b/src/geomap/crackedgemap.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "crackedgemap.hxx"
 #include "cppmap_utils.hxx"
 

--- a/src/geomap/crackedgemap.hxx
+++ b/src/geomap/crackedgemap.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef CRACKEDGEMAP_HXX
 #define CRACKEDGEMAP_HXX
 

--- a/src/geomap/facestatistics.hxx
+++ b/src/geomap/facestatistics.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_FACESTATISTICS_HXX
 #define VIGRA_FACESTATISTICS_HXX
 

--- a/src/geomap/labellut.hxx
+++ b/src/geomap/labellut.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef LABELLUT_HXX
 #define LABELLUT_HXX
 
@@ -43,7 +71,7 @@ class LabelLUT
                 currentLabel_ = next;
             return *this;
         }
-        
+
         MergedIterator operator++(int)
         {
             MergedIterator ret(*this);

--- a/src/geomap/polygon.hxx
+++ b/src/geomap/polygon.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_GEOMAP_POLYGON_HXX
 #define VIGRA_GEOMAP_POLYGON_HXX
 
@@ -199,9 +227,9 @@ class PointArray
 
 template<class Point>
 double partialArea(const PointArray<Point> &polygon);
-    
+
 /********************************************************************/
-    
+
 template<class POINT>
 class Polygon : public PointArray<POINT>
 {
@@ -700,7 +728,7 @@ Point centroid(const Polygon<Point> &polygon)
 }
 
 /********************************************************************/
-    
+
 template<class Point>
 double partialArea(const PointArray<Point> &polygon)
 {
@@ -710,7 +738,7 @@ double partialArea(const PointArray<Point> &polygon)
                    polygon[i][1]*polygon[i-1][0]);
     return result / 2.0;
 }
-    
+
 /********************************************************************/
 
 namespace detail {

--- a/src/geomap/vigra/crackconnections.hxx
+++ b/src/geomap/vigra/crackconnections.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_CRACKCONNECTIONS_HXX
 #define VIGRA_CRACKCONNECTIONS_HXX
 

--- a/src/geomap/vigra/dsl.hxx
+++ b/src/geomap/vigra/dsl.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_DSL_HXX
 #define VIGRA_DSL_HXX
 

--- a/src/geomap/vigra/map2d.hxx
+++ b/src/geomap/vigra/map2d.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_MAP2D_HXX
 #define VIGRA_MAP2D_HXX
 

--- a/src/python_bindings/cppmapmodule.cxx
+++ b/src/python_bindings/cppmapmodule.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #define PY_ARRAY_UNIQUE_SYMBOL geomap_PyArray_API
 #define NO_IMPORT_ARRAY
 #include <vigra/numpy_array.hxx>

--- a/src/python_bindings/cppmapmodule_stats.cxx
+++ b/src/python_bindings/cppmapmodule_stats.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #define PY_ARRAY_UNIQUE_SYMBOL geomap_PyArray_API
 #define NO_IMPORT_ARRAY
 #include <vigra/numpy_array.hxx>

--- a/src/python_bindings/cppmapmodule_utils.cxx
+++ b/src/python_bindings/cppmapmodule_utils.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #define PY_ARRAY_UNIQUE_SYMBOL geomap_PyArray_API
 #define NO_IMPORT_ARRAY
 #include <vigra/numpy_array.hxx>

--- a/src/python_bindings/dsl.cxx
+++ b/src/python_bindings/dsl.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "vigra/dsl.hxx"
 
 #include <boost/python.hpp>

--- a/src/python_bindings/exporthelpers.hxx
+++ b/src/python_bindings/exporthelpers.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef EXPORTHELPERS_HXX
 #define EXPORTHELPERS_HXX
 

--- a/src/python_bindings/geomapmodule.cxx
+++ b/src/python_bindings/geomapmodule.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #define PY_ARRAY_UNIQUE_SYMBOL geomap_PyArray_API
 //#define NO_IMPORT_ARRAY
 #include <vigra/numpy_array.hxx>

--- a/src/python_bindings/polygon.cxx
+++ b/src/python_bindings/polygon.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #define PY_ARRAY_UNIQUE_SYMBOL geomap_PyArray_API
 #define NO_IMPORT_ARRAY
 #include <vigra/numpy_array.hxx>

--- a/src/python_bindings/python_types.hxx
+++ b/src/python_bindings/python_types.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef PYTHON_TYPES_HXX_
 #define PYTHON_TYPES_HXX_
 

--- a/src/python_bindings/pythondiff2d.cxx
+++ b/src/python_bindings/pythondiff2d.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifdef _MSC_VER
 # pragma warning( disable : 4786 )
 #endif

--- a/src/python_bindings/statistics.cxx
+++ b/src/python_bindings/statistics.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #define PY_ARRAY_UNIQUE_SYMBOL geomap_PyArray_API
 #define NO_IMPORT_ARRAY
 #include <vigra/numpy_array.hxx>

--- a/src/python_bindings/subpixel_watersheds.cxx
+++ b/src/python_bindings/subpixel_watersheds.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "vigra/subpixel_watershed.hxx"
 
 #include "python_types.hxx"
@@ -5,7 +33,7 @@
 namespace python = boost::python;
 
 using namespace vigra;
-  
+
 template <class SPWSType>
 class SPWSWrapper : public SPWSType
 {

--- a/src/python_bindings/testmap.py
+++ b/src/python_bindings/testmap.py
@@ -1,3 +1,31 @@
+##########################################################################
+#
+#                Copyright 2007-2019 by Hans Meine
+#
+#     Permission is hereby granted, free of charge, to any person
+#     obtaining a copy of this software and associated documentation
+#     files (the "Software"), to deal in the Software without
+#     restriction, including without limitation the rights to use,
+#     copy, modify, merge, publish, distribute, sublicense, and/or
+#     sell copies of the Software, and to permit persons to whom the
+#     Software is furnished to do so, subject to the following
+#     conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the
+#     Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+#
+##########################################################################
+
 import geomap
 
 from vigra import Vector2, Size2D, addPathFromHere

--- a/src/python_bindings/vectorconv.cxx
+++ b/src/python_bindings/vectorconv.cxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #include "python_types.hxx"
 
 #include <vigra/numerictraits.hxx>

--- a/src/python_bindings/vigra/positionedmap.hxx
+++ b/src/python_bindings/vigra/positionedmap.hxx
@@ -1,3 +1,31 @@
+/************************************************************************/
+/*                                                                      */
+/*               Copyright 2007-2019 by Hans Meine                      */
+/*                                                                      */
+/*    Permission is hereby granted, free of charge, to any person       */
+/*    obtaining a copy of this software and associated documentation    */
+/*    files (the "Software"), to deal in the Software without           */
+/*    restriction, including without limitation the rights to use,      */
+/*    copy, modify, merge, publish, distribute, sublicense, and/or      */
+/*    sell copies of the Software, and to permit persons to whom the    */
+/*    Software is furnished to do so, subject to the following          */
+/*    conditions:                                                       */
+/*                                                                      */
+/*    The above copyright notice and this permission notice shall be    */
+/*    included in all copies or substantial portions of the             */
+/*    Software.                                                         */
+/*                                                                      */
+/*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND    */
+/*    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES   */
+/*    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND          */
+/*    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT       */
+/*    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,      */
+/*    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING      */
+/*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR     */
+/*    OTHER DEALINGS IN THE SOFTWARE.                                   */
+/*                                                                      */
+/************************************************************************/
+
 #ifndef VIGRA_POSITIONEDMAP_HXX
 #define VIGRA_POSITIONEDMAP_HXX
 


### PR DESCRIPTION
This adds the license headers and thus fixes #10

These files already had a license header so I left them untouched:

> src/cellimage/watershed.cxx
src/geomap/filteriterator.hxx
src/geomap/vigra/oversampling.hxx
src/geomap/vigra/subpixel_watershed.hxx
src/geomap/python_bindings/pythonutil.hxx