### PR TITLE
Allow setting the output name of the libgeomap library from the outside

### DIFF
--- a/src/geomap/CMakeLists.txt
+++ b/src/geomap/CMakeLists.txt
@@ -12,6 +12,11 @@ ADD_LIBRARY(libgeomap ${LIBTYPE}
     crackedgemap.cxx
 )
 
+SET(libgeomap_OUTPUT_NAME "libgeomap" CACHE STRING "geomap core library output name")
+
+SET_TARGET_PROPERTIES(libgeomap PROPERTIES
+    OUTPUT_NAME ${libgeomap_OUTPUT_NAME})
+
 INSTALL(TARGETS libgeomap
 #        EXPORT vigra-targets
         RUNTIME DESTINATION bin


### PR DESCRIPTION
This allows setting the output name of the libgeomap from the outside by passing the desired value:

```
cmake <path/to/sources> -Dlibgeomap_OUTPUT_NAME:STRING="geomap"
```